### PR TITLE
Include task to build network credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ An Ansible Role to create a Credential in Ansible Tower.
 |`tower_cred_ssh_key_path`|""|no|Path to a SSH private key for an Ansible Tower credential to use.|
 |`tower_cred_ssh_key_pass`|"ASK"|no|Password to unlock a SSH private key.  Use the value "ASK" for password prompting.|
 |`tower_cred_vault_pass`|"ASK"|no|Password for your Ansible Vault file. Use the value "ASK" for password prompting.|
+|`tower_cred_authorize`|False|no|Whether or not to enable Authorize for network devices.|
+|`tower_cred_authorize_password`|""|no|Authorize password for network devices.|
 ## Playbook Examples
 ### Standard Role Usage
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,6 @@ tower_pass: "" #Put in a vault at vars/tower-secrets.yml when tower_secrets: Tru
 tower_org: ""
 tower_cred_name: ""
 tower_cred_user: ""
-tower_cred_pass: "ASK"
 tower_cred_desc: ""
 tower_cred_type: ""
 # tower_cred_ssh_key_path: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
     tower_verify_ssl: "{{ tower_verify_ssl }}"
     name: "{{ tower_cred_name }}"
     username: "{{ tower_cred_user }}"
-    password: "{{ tower_cred_pass }}"
+    password: "{{ tower_cred_pass | default(omit) }}"
     description: "{{ tower_cred_desc | default(omit) }}"
     ssh_key_data: "{{ tower_cred_ssh_key_path | default(omit) }}"
     ssh_key_unlock: "{{ tower_cred_ssh_key_pass | default(omit) }}"
@@ -55,11 +55,24 @@
     state: "present"
   when: tower_cred_type == "vault"
 
-# TODO:
 # Type net
 - name: Create Ansible Tower Credential | Network Credential
-  debug:
-    msg: "This role does not yet support this type."
+  tower_credential:
+    tower_host: "{{ tower_url }}"
+    tower_username: "{{ tower_user }}"
+    tower_password: "{{ tower_pass }}"
+    organization: "{{ tower_org }}"
+    tower_verify_ssl: "{{ tower_verify_ssl }}"
+    name: "{{ tower_cred_name }}"
+    description: "{{ tower_cred_desc | default(omit) }}"
+    kind: "{{ tower_cred_type }}"
+    username: "{{ tower_cred_user }}"
+    password: "{{ tower_cred_pass | default(omit) }}"
+    ssh_key_data: "{{ tower_cred_ssh_key_path | default(omit) }}"
+    ssh_key_unlock: "{{ tower_cred_ssh_key_pass | default(omit) }}"
+    state: "present"
+    authorize: "{{ tower_cred_authorize | default('False') }}"
+    authorize_password: "{{ tower_cred_authorize_password | default(omit) }}"
   when: tower_cred_type == "net"
 
 # Type aws


### PR DESCRIPTION
Included a task for building out network credentials and updated README with two new variables unique to network credentials

I also removed the default tower_cred_pass from defaults and applied the defaults directly to the task variables because passwords (scm/network) that don't have the "prompt on launch" feature were being entered as "ASK"